### PR TITLE
add kind for Asset Pack of Play Asset Delivery

### DIFF
--- a/modules/androidstudio/_preload.lua
+++ b/modules/androidstudio/_preload.lua
@@ -52,7 +52,7 @@
 
 		toolset = "gcc",
 
-		valid_kinds = { "WindowedApp", "SharedLib", "StaticLib", "Utility", "None" },
+		valid_kinds = { "WindowedApp", "SharedLib", "StaticLib", "Utility", "AssetPack", "None" },
 		valid_languages = { "C", "C++" },
 		valid_tools = {
 			cc = { "clang", 'gcc' },
@@ -73,7 +73,8 @@
 		end,
 
 		onProject = function(prj)
-			if prj.kind == p.WINDOWEDAPP then
+			if prj.kind == p.WINDOWEDAPP
+			or prj.kind == p.ASSETPACK then
 				p.generate(prj, "build.gradle", p.modules.androidstudio.generate_project_buildgradle)
 			end
 			if prj.kind == p.SHAREDLIB

--- a/modules/androidstudio/_preload.lua
+++ b/modules/androidstudio/_preload.lua
@@ -9,6 +9,8 @@
 -- Register Android Studio workspace API.
 --
 
+	p.api.addAllowed("kind", p.ASSETPACK)
+
 	-- build.gradle
 	p.api.register {
 		name = "workspacebuildgradle",

--- a/modules/androidstudio/androidstudio_cmakeliststxt.lua
+++ b/modules/androidstudio/androidstudio_cmakeliststxt.lua
@@ -68,12 +68,14 @@
 	function m.workspace(wks)
 		for prj in p.workspace.eachproject(wks) do
 			for cfg in project.eachconfig(prj) do
-				_p(0, ifcondition(cfg))
-				_p(1, 'add_subdirectory(')
-				_p(2, cmake.quoted(cmake.getpath(prj.location)))
-				_p(2, cmake.quoted(cmake.getpath(cfg.objdir)))
-				_p(2, ')')
-				_p(0, 'endif()')
+				if prj.kind ~= p.ASSETPACK then
+					_p(0, ifcondition(cfg))
+					_p(1, 'add_subdirectory(')
+					_p(2, cmake.quoted(cmake.getpath(prj.location)))
+					_p(2, cmake.quoted(cmake.getpath(cfg.objdir)))
+					_p(2, ')')
+					_p(0, 'endif()')
+				end
 			end
 			p.outln('')
 		end

--- a/modules/androidstudio/tests/test_androidstudio_gradle.lua
+++ b/modules/androidstudio/tests/test_androidstudio_gradle.lua
@@ -26,7 +26,11 @@
 		project '*'
 		location 'Workspace'
 		project 'MyProject'
+		kind 'WindowedApp'
 		location 'Workspace/MyProject'
+		project 'MyAssetPack'
+		kind 'AssetPack'
+		location 'Workspace/MyAssetPack'
 		wks = p.oven.bakeWorkspace(wks)
 		prj = test.getproject(wks, 1)
 		androidstudio.generate_workspace_settingsgradle(wks)
@@ -40,9 +44,24 @@
 		project '*'
 		location 'Workspace'
 		project 'MyProject'
+		kind 'WindowedApp'
 		location 'Workspace/MyProject'
 		wks = p.oven.bakeWorkspace(wks)
 		prj = test.getproject(wks, 1)
+		androidstudio.generate_project_buildgradle(prj)
+	end
+
+	local function prepare_projectbuildgradle_assetpack()
+		project '*'
+		location 'Workspace'
+		project 'MyProject'
+		kind 'WindowedApp'
+		location 'Workspace/MyProject'
+		project 'MyAssetPack'
+		kind 'AssetPack'
+		location 'Workspace/MyAssetPack'
+		wks = p.oven.bakeWorkspace(wks)
+		prj = test.getproject(wks, 2)
 		androidstudio.generate_project_buildgradle(prj)
 	end
 
@@ -55,10 +74,14 @@
 	function suite.OnWorkspaceSettingsGradle()
 		project 'MyProject'
 		kind 'WindowedApp'
+		project 'MyAssetPack'
+		kind 'AssetPack'
 		prepare_workspacesettingsgradle()
 		test.capture [[
 include(":MyProject")
 project(":MyProject").setProjectDir(file("MyProject"))
+
+include(":MyAssetPack")
 		]]
 	end
 
@@ -573,6 +596,24 @@ android {
 			}
 		}
 	}
+}
+		]]
+	end
+
+	function suite.OnProjectBuildGradle_AssetPack()
+		project 'MyAssetPack'
+		projectbuildgradle {
+			['assetPack.dynamicDelivery.deliveryType'] = 'install-time',
+		}
+		prepare_projectbuildgradle_assetpack()
+		test.capture [[
+apply plugin: "com.android.asset-pack"
+
+assetPack {
+	dynamicDelivery {
+		deliveryType = "install-time"
+	}
+	packName = "MyAssetPack"
 }
 		]]
 	end

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -711,6 +711,7 @@
 			"WindowedApp",
 			"Utility",
 			"SharedItems",
+			"AssetPack",
 		},
 	}
 

--- a/src/_premake_init.lua
+++ b/src/_premake_init.lua
@@ -711,7 +711,6 @@
 			"WindowedApp",
 			"Utility",
 			"SharedItems",
-			"AssetPack",
 		},
 	}
 

--- a/src/base/_foundation.lua
+++ b/src/base/_foundation.lua
@@ -61,6 +61,7 @@
 	premake.X86_64      = "x86_64"
 	premake.ARM         = "ARM"
 	premake.ARM64       = "ARM64"
+	premake.ASSETPACK   = "AssetPack"
 
 
 


### PR DESCRIPTION
**What does this PR do?**

Android Studio向けに、Play Asset Delivery の Asset Pack をプロジェクトに追加するため、
kindに 'AssetPack' を追加しました。
https://developer.android.com/guide/app-bundle/asset-delivery/build-native-java?hl=ja

**How does this PR change Premake's behavior?**

プロジェクトの kind に 'AssetPack' を指定すると、locationで指定したプロジェクトのフォルダパスに
Asset Pack のbuild.gradleを生成し、そのフォルダパスをsettings.gradleに追加します。

**Anything else we should know?**

ありません

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Add unit tests showing fix or feature works; all tests pass
- [x] Mention any [related issues](https://github.com/premake/premake-core/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/premake/premake-core/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] Minimize the number of commits

*You can now [support Premake on our OpenCollective](https://opencollective.com/premake). Your contributions help us spend more time responding to requests like these!*
